### PR TITLE
French translation

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -12,7 +12,9 @@
         <platform>all</platform>
         <summary lang="de">Fotojournalismus</summary>
         <summary lang="en">Photojournalism</summary>
+        <summary lang="fr">Photojournalisme</summary>
         <description lang="de">Dieses Addon bietet schöne Alben und Photos von Fotojournalismus Webseiten.[CR][CR]- Boston.com: The Big Picture[CR]- The Atlantic: In Focus[CR]- Sacramento Bee: The Frame[CR]- Wallstreetjournal: The Photo Journal[CR]- TotallyCoolPix.com[CR]- Time.com: LightBox - Closeup</description>
         <description lang="en">This addon provides beautiful albums and photos from some nice photojournalism websites.[CR]- Boston.com: The Big Picture[CR]- The Atlantic: In Focus[CR]- Sacramento Bee: The Frame[CR]- Wallstreetjournal: The Photo Journal[CR]- TotallyCoolPix.com[CR]- Time.com: LightBox - Closeup</description>
+        <description lang="fr">Cet addon affiche de magnifiques albums et photos de plusieurs sites Web de photojournalisme.[CR]- Boston.com: The Big Picture[CR]- The Atlantic: In Focus[CR]- Sacramento Bee: The Frame[CR]- Wallstreetjournal: The Photo Journal[CR]- TotallyCoolPix.com[CR]- Time.com: LightBox - Closeup</description>
     </extension>
 </addon>

--- a/resources/language/French/strings.xml
+++ b/resources/language/French/strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<strings>
+    <!-- Help -->
+    <string id="32001">Gauche + Droite = Changer d'album/de photo</string>
+    <string id="32002">Haut + Bas = Changer de source</string>
+    <string id="32003">Sélection = Enter dans l'album</string>
+    <string id="32004">Retour = Retour à l'album/quitter l'addon</string>
+    <string id="32005">Info = Affiche la description</string>
+    <string id="32006">Contexte = Télécharger l'album</string>
+    <string id="32007">Play = Démarrer le diaporama</string>
+    <string id="32008">0 = Changer le ratio de l'image</string>
+    <!-- Settings -->
+    <string id="32100">Ne plus afficher cette aide à l'avenir</string>
+    <string id="32110">Ratio de l'image par défaut</string>
+    <string id="32111">Étiré</string>
+    <string id="32112">Original</string>
+    <string id="32120">Afficher les flèches</string>
+    <string id="32130">Diaporama aléatoire</string>
+    <string id="32140">Chemin de téléchargement de l'album</string>
+    <!-- Settings categories -->
+    <string id="32200">Aide</string>
+    <string id="32201">Paramètres</string>
+    <!-- Script strings -->
+    <string id="32300">Choirir le chemin de téléchargement par défaut</string>
+    <string id="32301">Récupération des données...</string>
+    <string id="32302">Élément %d/%d</string>
+    <string id="32303">Élément courant : %s %d%%</string>
+    <string id="32304">Télécharge vers : %s</string>
+</strings>


### PR DESCRIPTION
Hi,

I created a branch translation-fr with only one commit including translation for strings.xml and addon.xml
I hope it's ok

I tested 3.0.0 on a fresh xbmc ( no .xbmc ) and I can configure ok but the addon does not start or show any picture.

$ xbmc --version
XBMC Media Center 11.0-BETA3 Git:Unknown

Here is the log :

 ERROR: ADDON: extension '' is not currently supported for service addon
 ERROR: Texture manager unable to load file: /home/stombi/Images/script.image.bigpictures.zip/icon.png
NOTICE: -->Python Interpreter Initialized<--
NOTICE: The Big Picture: addon version: 3.0.0 started in SCRIPT-mode
 ERROR: GetDirectory - Error getting /home/stombi/.xbmc/addons/script.image.bigpictures/resources/skins/Default
 ERROR: Error Type: <type 'exceptions.TypeError'>
 ERROR: Error Contents: XML File for Window is missing
 ERROR: Traceback (most recent call last):
      File "/home/stombi/.xbmc/addons/script.image.bigpictures/addon.py", line 29, in <module>
        script.GUI(skin, ADDON_PATH).doModal()
    TypeError: XML File for Window is missing
