### PR TITLE
Typo in French translation

### DIFF
--- a/resources/language/French/strings.xml
+++ b/resources/language/French/strings.xml
@@ -21,7 +21,7 @@
     <string id="32200">Aide</string>
     <string id="32201">Paramètres</string>
     <!-- Script strings -->
-    <string id="32300">Choirir le chemin de téléchargement par défaut</string>
+    <string id="32300">Choisir le chemin de téléchargement par défaut</string>
     <string id="32301">Récupération des données...</string>
     <string id="32302">Élément %d/%d</string>
     <string id="32303">Élément courant : %s %d%%</string>


### PR DESCRIPTION
Hi, just a typo 
Anyway the addon 3.0.0 works perfectly now, great job.
I still believe that "Choose default download path" should be in the Settings dialog and "Album download path" should be when you press the context button (or c) not the other way around.
